### PR TITLE
typos from prod

### DIFF
--- a/publisher/config.py
+++ b/publisher/config.py
@@ -178,7 +178,7 @@ def get_files(options, cfg):
         from publisher import schema, upload
 
         workspace_url, auth_token = upload.get_auth(cfg)
-        release_url = f"{workspace_url}/release/{release}"
+        release_url = f"{workspace_url}/release/{options.release}"
         response, body = upload.release_hatch("GET", release_url, None, auth_token)
         index = schema.FileList(**json.loads(body))
 

--- a/publisher/release.py
+++ b/publisher/release.py
@@ -38,7 +38,7 @@ def configure_logging():
     root.setLevel(logging.NOTSET)
     cfg = config.get_config(os.environ)
 
-    private_token = config.get("PRIVATE_REPO_ACCESS_TOKEN")
+    private_token = cfg.get("PRIVATE_REPO_ACCESS_TOKEN")
     if private_token:
         # info level logs go straight to the user using the default format, but
         # redacted
@@ -223,7 +223,7 @@ def main(study_repo_url, token, files, commit_msg, user, backend):
 def release(options, release_dir):
     try:
         cfg = config.load_config(options, release_dir)
-        files = get_files(options, cfg)
+        files = config.get_files(options, cfg)
 
         if not options.yes:
             logger.info("\n".join(str(f) for f in files))
@@ -257,7 +257,7 @@ def release(options, release_dir):
             from publisher import upload
 
             if options.release:
-                upload.upload_to_release(files, release, cfg)
+                upload.upload_to_release(files, options.release, cfg)
             else:
                 upload.main(files, cfg)
 


### PR DESCRIPTION
- Soft-disable releasing to github.
- ensure default behaviour is new releases :facepalm:
- Update PyCQA URLs
- Sync `.pre-commit-config.yaml` to requirements
- Use new release API
- Fix index url used in release creation
- fix logging handler initialisation
- remove old git based functions and tests
- Add support for uploading to pre-existing release
- take release from first file if it is a path to a release dir
- Fix tests on windows
- fix: supress the github issue being created
- fix: some fixes from testing in prod
