### PR TITLE
Tweak wording to reference IG team

### DIFF
--- a/publisher/config.py
+++ b/publisher/config.py
@@ -125,7 +125,9 @@ def load_config(options, release_dir, env=os.environ):
 
     if github_username is None:
         sys.exit(
-            "Your user is not in the local Level 4 list of github users. Please ask tech-support to add your github username."
+            "Your username is not in the list of names allowed to release files.\n"
+            "If you believe it should be, please ask tech-support to review this with"
+            "the IG team."
         )
 
     workspace = manifest["workspace"]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -177,7 +177,7 @@ def test_load_config_username_not_allowed(options, tmp_path, monkeypatch):
     with pytest.raises(SystemExit) as exc_info:
         config.load_config(options, tmp_path, env=env)
 
-    assert "user is not in" in str(exc_info.value)
+    assert "username is not in" in str(exc_info.value)
 
 
 def test_load_config_username_allowed_users_list_still_blocks(
@@ -197,7 +197,7 @@ def test_load_config_username_allowed_users_list_still_blocks(
     with pytest.raises(SystemExit) as exc_info:
         config.load_config(options, tmp_path, env=env)
 
-    assert "user is not in" in str(exc_info.value)
+    assert "username is not in" in str(exc_info.value)
 
 
 def test_load_config_new_publish_as_arg(options, tmp_path, default_config):


### PR DESCRIPTION
The previous wording suggested the tech-support were the gatekeepers here.

See related thread:
https://bennettoxford.slack.com/archives/C0270Q313H7/p1697724056936269?thread_ts=1697721818.215169&cid=C0270Q313H7