### PR TITLE
Update github user message.

### DIFF
--- a/publisher/config.py
+++ b/publisher/config.py
@@ -125,7 +125,9 @@ def load_config(options, release_dir, env=os.environ):
 
     if github_username is None:
         sys.exit(
-            "Your user is not in the local Level 4 list of github users. Please ask tech-support to add your github username."
+            f"We do not know who {local_username} is in Github. "
+            f"Please ask tech-support to add the correct Github username for user {local_username} in the osrelease configuration.\n"
+            "Note: this does not give you permission to release anything, but is a required first step."
         )
 
     workspace = manifest["workspace"]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -172,12 +172,12 @@ def test_load_config_username_not_allowed(options, tmp_path, monkeypatch):
     f = tmp_path / "file.txt"
     f.write_text("test")
     options.files = [str(f)]
-    monkeypatch.setattr("publisher.config.getpass.getuser", lambda: "user")
+    monkeypatch.setattr("publisher.config.getpass.getuser", lambda: "invaliduser")
 
     with pytest.raises(SystemExit) as exc_info:
         config.load_config(options, tmp_path, env=env)
 
-    assert "user is not in" in str(exc_info.value)
+    assert "invaliduser" in str(exc_info.value)
 
 
 def test_load_config_username_allowed_users_list_still_blocks(
@@ -197,7 +197,7 @@ def test_load_config_username_allowed_users_list_still_blocks(
     with pytest.raises(SystemExit) as exc_info:
         config.load_config(options, tmp_path, env=env)
 
-    assert "user is not in" in str(exc_info.value)
+    assert "invaliduser" in str(exc_info.value)
 
 
 def test_load_config_new_publish_as_arg(options, tmp_path, default_config):


### PR DESCRIPTION
This seems to be confusing people.

THIS IS NOT AN IG ISSUE. It's just some missing config. Adding a github username to the config as per https://bennettinstitute-team-manual.pages.dev/tech-group/playbooks/opensafely-tpp-level-4/#osrelease does not grant *any* permissions at all.